### PR TITLE
Use Awareness clientID property instead of y-sync's ydoc clientID.

### DIFF
--- a/src/plugins/cursor-plugin.js
+++ b/src/plugins/cursor-plugin.js
@@ -39,7 +39,7 @@ export const createDecorations = (state, awareness, createCursor) => {
     return DecorationSet.create(state.doc, [])
   }
   awareness.getStates().forEach((aw, clientId) => {
-    if (clientId === y.clientID) {
+    if (clientId === awareness.clientID) {
       return
     }
     if (aw.cursor != null) {


### PR DESCRIPTION
Awareness got its own clientID field in [this commit](https://github.com/yjs/y-protocols/commit/59234fbd52e83b1b9b6a1fac67874307ff1b5511), but yCursorPlugin uses the ydoc's clientID to prevent showing one's own cursor. If these values diverge, it results in an unnecessary cursor decoration.